### PR TITLE
update the new page template

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -59,6 +59,10 @@ title: Thing you're writing a standard about
 expires: yyyy-mm-dd (6 months from now)
 ---
 
+# <%%= current_page.data.title %>
+
+<%%= partial :expires %>
+
 Introduction of a couple of paragraphs to explain why the thing you're
 writing a standard about is important.
 


### PR DESCRIPTION
This updates the new page template to ensure there's a `<h1>` tag and an
expiry banner.

Because we have erb-in-erb, the double percent sign is needed to
render correctly on the page.  ie

    <%%= partial :expires %>

renders to

    <%= partial :expires %>

which is what we want.