### PR TITLE
add clarification banner

### DIFF
--- a/source/layouts/core.erb
+++ b/source/layouts/core.erb
@@ -46,6 +46,7 @@
 
         <div class="app-pane__content toc-open-disabled">
           <main id="content" class="technical-documentation" data-module="anchored-headings">
+            <div class="page-banner"><p>The GDS Way and its content is intended for internal use by the GDS community.</p></div>
             <%= yield %>
           </main>
 

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -24,6 +24,7 @@ $desktop-breakpoint: 992px !default;
 @import "modules/footer";
 @import "modules/govuk-logo";
 @import "modules/header";
+@import "modules/page-banner";
 @import "modules/phase-banner";
 @import "modules/skip-link";
 @import "modules/technical-documentation";

--- a/source/stylesheets/modules/_page-banner.scss
+++ b/source/stylesheets/modules/_page-banner.scss
@@ -1,0 +1,26 @@
+/**
+ * Page Banner Component
+ *
+ * Example Usage:
+ *
+ * <div class="page-banner">
+ *   Lorem ipsum dolor est
+ * </div>
+ */
+
+.page-banner {
+  padding: 10px 0 8px;
+
+  @include media(tablet) {
+    padding-bottom: 10px;
+  }
+
+  border-bottom: 1px solid $border-colour;
+
+  p {
+    margin: 0;
+    color: $banner-text-colour;
+    @include core-16;
+  }
+}
+


### PR DESCRIPTION
adds a banner to make it clear that this content is intended for a GDS
internal audience only.

copy by @soupdragon99 

screenshot: 
<img width="998" alt="screen shot 2017-08-01 at 09 53 14" src="https://user-images.githubusercontent.com/581269/28817212-7078942e-769f-11e7-8a1f-2853442e3252.png">

