### PR TITLE
Add links back to the repo

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -10,6 +10,7 @@ phase: Beta
 # Links to show on right-hand-side of header
 header_links:
   Documentation: /
+  GitHub: https://github.com/alphagov/gds-tech
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id:

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -12,8 +12,8 @@ It complements the [Service Manual](https://www.gov.uk/service-manual) which
 covers service design more broadly.
 
 If you think that you can contribute a change to this repository which reflects
-current practice at GDS, make a pull request to this repo and we'll discuss it
-at the Tech Ops Forum meeting and in the
+current practice at GDS, make a pull request to [this repo](https://github.com/alphagov/gds-tech)
+and we'll discuss it at the Tech Ops Forum meeting and in the
 [#tech-ops-forum Slack channel](https://govuk.slack.com/messages/tech-ops-forum/).
 
 Products at GDS must follow the


### PR DESCRIPTION
There's a [general call for contributions][1], but no link to the repo.  I've added an inline link and a header link, but happy if people would rather this went elsewhere.

[1]: https://github.com/alphagov/gds-tech/blob/f2cec941568445c146255e11ecd418a7b25b9383/source/index.html.md.erb#L14
![screen shot 2017-08-01 at 16 54 05](https://user-images.githubusercontent.com/773037/28834420-15068ef8-76da-11e7-8f3f-96ebb4f73cc3.png)
