### PR TITLE
deploy app to gds-way and redirect traffic from old app

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,10 @@
 ---
 applications:
-- name: gds-tech-docs
+- name: gds-way
   memory: 64M
   path: ./build
+  buildpack: staticfile_buildpack
+- name: gds-tech-docs
+  memory: 64M
+  path: ./redirect
   buildpack: staticfile_buildpack

--- a/redirect/nginx.conf
+++ b/redirect/nginx.conf
@@ -1,0 +1,13 @@
+worker_processes 1;
+daemon off;
+
+error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
+events { worker_connections 1024; }
+
+http {
+  server {
+    listen <%= ENV["PORT"] %>;
+    server_name localhost;
+    return 301 https://gds-way.cloudapps.digital$request_uri;
+  }
+}


### PR DESCRIPTION
This deploys the site to a new app called `gds-way`.  It also sets up
a static nginx at the old app to redirect all traffic to the new URLs.

I tested this locally by deploying the redirect to a site called
`gds-tech-docs-test` and verifying that the redirects worked as
expected.