### PR TITLE
Add some basic guidance on naming things

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -41,8 +41,9 @@ are still working for GDS as an organization.
 
 ### Building software
 
-- [Choosing programming languages](standards/programming-languages.html)
-- [Storing source code](standards/source-code.html)
+- [naming things](standards/naming-things.html)
+- [choosing programming languages](standards/programming-languages.html)
+- [storing source code](standards/source-code.html)
 
 ### Operating services
 

--- a/source/standards/naming-things.html.md.erb
+++ b/source/standards/naming-things.html.md.erb
@@ -1,0 +1,53 @@
+---
+title: Naming things
+expires: 2018-02-04
+---
+
+# <%= current_page.data.title %>
+
+<%= partial :expires %>
+
+## User needs
+
+Users should to be able to infer a basic understanding of what a given thing
+does from its name.
+
+
+## Principles
+
+Names should be self-descriptive – you should be able to infer a basic
+understanding of what something does from its name.
+
+Avoid naming things using puns or with a brand, as this will only make it
+difficult for others to understand what the thing does.
+
+Ensure you use the same name consistently whenever you're referring to the same
+thing. For example, in most cases the name of an application's GitHub
+repository should match its hostname.
+
+
+### Examples
+
+These applications are well named as they communicate their purpose reasonably
+clearly:
+
+- Signon (which used to be called signonontron2000)
+- Manuals Publisher
+- Smart Answers
+- Digital Marketplace Admin Frontend
+- Notifications PaaS Autoscaler
+
+The names of these applications are ambiguous and possibly confusing:
+
+- Panopticon
+- Whitehall
+- Rummager
+- Maslow
+- Magna Charta
+
+
+## Other resources
+
+The service manual has [good guidance for naming
+services](https://www.gov.uk/service-manual/design/naming-your-service), a lot
+of which will also be relevant when naming applications or packages.


### PR DESCRIPTION
Rather than including guidance on naming things everywhere those names need to be considered (e.g, naming GitHub repos and in naming packages), add some general documentation on how we name things at GDS which we can refer to as appropriate.

This is loosely based on an existing [GOV.UK RFC] as well as my personal understanding of how we name things.

[GOV.UK RFC]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-063-naming-new-apps-gems-on-gov-uk.md