### PR TITLE
change Beta banner to Alpha

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -5,7 +5,7 @@ host: gds-way.cloudapps.digital
 show_govuk_logo: false
 service_name: The GDS Way
 service_link: https://gds-way.cloudapps.digital
-phase: Beta
+phase: Alpha
 
 # Links to show on right-hand-side of header
 header_links:


### PR DESCRIPTION
this isn't a service so the service phase names don't really apply
but... if it were a service, beta wouldn't be the right description.
We're too early and have too many things still to validate.