### PR TITLE
Update monitoring.html.md.erb

### DIFF
--- a/source/standards/monitoring.html.md.erb
+++ b/source/standards/monitoring.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-expires: 2017-09-01
+expires: 2018-03-01
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
Changed the guidance expiry date to 2018-03-01, agreed at August's Tech Forum.