### PR TITLE
Update source-code.html.md.erb

### DIFF
--- a/source/standards/source-code.html.md.erb
+++ b/source/standards/source-code.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Source code
-expires: 2017-09-01
+expires: 2018-03-01
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
Changed the guidance expiry date to 2018-03-01, agreed at August's Tech Forum.