### PR TITLE
Amended expiry date - programming-languages

### DIFF
--- a/source/standards/programming-languages.html.md.erb
+++ b/source/standards/programming-languages.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Programming languages
-expires: 2017-10-01
+expires: 2017-12-01
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
Changed guidance expiry date to 2017-12-01