### PR TITLE
Amended expiry date - Supporting Services

### DIFF
--- a/source/standards/supporting-services.html.md.erb
+++ b/source/standards/supporting-services.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Supporting services
-expires: 2017-10-01
+expires: 2017-12-01
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
Changed guidance expiry date to 2017-12-01